### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/coinfo/Cargo.toml
+++ b/coinfo/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description="A CLI tool that provides useful information about cryptocurrencies"
+repository = "https://github.com/Amovane/coinfo/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Allow crates.io and others link back to the repo